### PR TITLE
Implement Optional Attendee Feature with Unit Testing

### DIFF
--- a/portfolio/src/main/webapp/style.css
+++ b/portfolio/src/main/webapp/style.css
@@ -69,10 +69,14 @@ a #link {
   opacity: 0.7;
 }
 
-.card {
+.card-deck .card {
+  -ms-flex: 1 0 0%;
   background-color: #ffffff80;
   color: #000;
+  flex: 1 0 0%;
+  margin-right: 1rem;
   margin-bottom: 1rem;
+  margin-left: 1rem;
 }
 
 .btn-primary {

--- a/portfolio/src/main/webapp/style.css
+++ b/portfolio/src/main/webapp/style.css
@@ -118,7 +118,6 @@ a #link {
 
 .timeline-container::after {
   background-color: #fff;
-  border: 4px solid #c0b6b6;
   border-radius: 50%;
   content: '';
   height: 25px;

--- a/walkthroughs/week-5-tdd/project/src/main/java/com/google/sps/FindMeetingQuery.java
+++ b/walkthroughs/week-5-tdd/project/src/main/java/com/google/sps/FindMeetingQuery.java
@@ -39,10 +39,10 @@ public final class FindMeetingQuery {
     Collection<Event> optionalAttendeeEvents = getOptionalAttendeeEvents(events, optionalAttendees);
 
     // No required attendees case.
-    if (requiredAttendees.size()==0) {
+    if (requiredAttendees.size() == 0) {
 
       // Check for optional attendees and count them in if in range.
-      if (optionalAttendees.size()>0) {
+      if (optionalAttendees.size() > 0) {
         possibleMeetingTimes.addAll(getRanges(optionalAttendees, optionalAttendeeEvents, duration));
       } else {
         possibleMeetingTimes.add(TimeRange.WHOLE_DAY);
@@ -50,7 +50,7 @@ public final class FindMeetingQuery {
       return possibleMeetingTimes;
 
       // Longer than a day case.
-    } else if (duration>1440) {
+    } else if (duration > 1440) {
       return possibleMeetingTimes;
     }
 
@@ -58,7 +58,7 @@ public final class FindMeetingQuery {
 
     // Add any optional attendee that is free by removing their event time from overall meeting
     // ranges.
-    if (optionalAttendeeEvents.size()>0) {
+    if (optionalAttendeeEvents.size() > 0) {
       ArrayList<TimeRange> optionalMeetingTimes = new ArrayList<TimeRange>();
       for (Event event : optionalAttendeeEvents) {
         optionalMeetingTimes.add(event.getWhen());
@@ -89,7 +89,7 @@ public final class FindMeetingQuery {
       TimeRange when = event.getWhen();
 
       // Establish time change for overlapping possibilities.
-      if (possibleMeetingTimes.size()>=1 && when.overlaps(prevTimeRange)) {
+      if (possibleMeetingTimes.size() >= 1 && when.overlaps(prevTimeRange)) {
         if (currentTime < when.end()) {
           currentTime = when.end();
         }
@@ -144,7 +144,7 @@ public final class FindMeetingQuery {
    * @param duration The amount of time required for meeting request. Must be non-null.
    */
   public boolean durationChecker(TimeRange range, long duration) {
-    if (range.duration()>=duration) {
+    if (range.duration() >= duration) {
       return true;
     }
     return false;

--- a/walkthroughs/week-5-tdd/project/src/main/java/com/google/sps/FindMeetingQuery.java
+++ b/walkthroughs/week-5-tdd/project/src/main/java/com/google/sps/FindMeetingQuery.java
@@ -39,10 +39,10 @@ public final class FindMeetingQuery {
     Collection<Event> optionalAttendeeEvents = getOptionalAttendeeEvents(events, optionalAttendees);
 
     // No required attendees case.
-    if (requiredAttendees.size() == 0) {
+    if (requiredAttendees.size()==0) {
 
-      // Check for optional attendees and count them in if in range
-      if (optionalAttendees.size() > 0) {
+      // Check for optional attendees and count them in if in range.
+      if (optionalAttendees.size()>0) {
         possibleMeetingTimes.addAll(getRanges(optionalAttendees, optionalAttendeeEvents, duration));
       } else {
         possibleMeetingTimes.add(TimeRange.WHOLE_DAY);
@@ -50,7 +50,7 @@ public final class FindMeetingQuery {
       return possibleMeetingTimes;
 
       // Longer than a day case.
-    } else if (duration > 1440) {
+    } else if (duration>1440) {
       return possibleMeetingTimes;
     }
 
@@ -58,7 +58,7 @@ public final class FindMeetingQuery {
 
     // Add any optional attendee that is free by removing their event time from overall meeting
     // ranges.
-    if (optionalAttendeeEvents.size() > 0) {
+    if (optionalAttendeeEvents.size()>0) {
       ArrayList<TimeRange> optionalMeetingTimes = new ArrayList<TimeRange>();
       for (Event event : optionalAttendeeEvents) {
         optionalMeetingTimes.add(event.getWhen());
@@ -89,7 +89,7 @@ public final class FindMeetingQuery {
       TimeRange when = event.getWhen();
 
       // Establish time change for overlapping possibilities.
-      if (possibleMeetingTimes.size() >= 1 && when.overlaps(prevTimeRange)) {
+      if (possibleMeetingTimes.size()>=1 && when.overlaps(prevTimeRange)) {
         if (currentTime < when.end()) {
           currentTime = when.end();
         }
@@ -144,7 +144,7 @@ public final class FindMeetingQuery {
    * @param duration The amount of time required for meeting request. Must be non-null.
    */
   public boolean durationChecker(TimeRange range, long duration) {
-    if (range.duration() >= duration) {
+    if (range.duration()>=duration) {
       return true;
     }
     return false;

--- a/walkthroughs/week-5-tdd/project/src/test/java/com/google/sps/FindMeetingQueryTest.java
+++ b/walkthroughs/week-5-tdd/project/src/test/java/com/google/sps/FindMeetingQueryTest.java
@@ -32,6 +32,7 @@ public final class FindMeetingQueryTest {
   // Some people that we can use in our tests.
   private static final String PERSON_A = "Person A";
   private static final String PERSON_B = "Person B";
+  private static final String PERSON_C = "Person C";
 
   // All dates are the first day of the year 2020.
   private static final int TIME_0800AM = TimeRange.getTimeInMinutes(8, 0);
@@ -39,7 +40,10 @@ public final class FindMeetingQueryTest {
   private static final int TIME_0900AM = TimeRange.getTimeInMinutes(9, 0);
   private static final int TIME_0930AM = TimeRange.getTimeInMinutes(9, 30);
   private static final int TIME_1000AM = TimeRange.getTimeInMinutes(10, 0);
+  private static final int TIME_1030AM = TimeRange.getTimeInMinutes(10, 30);
   private static final int TIME_1100AM = TimeRange.getTimeInMinutes(11, 00);
+  private static final int TIME_1130AM = TimeRange.getTimeInMinutes(11, 30);
+  private static final int TIME_1230PM = TimeRange.getTimeInMinutes(12, 30);
 
   private static final int DURATION_30_MINUTES = 30;
   private static final int DURATION_60_MINUTES = 60;
@@ -305,6 +309,186 @@ public final class FindMeetingQueryTest {
                 Arrays.asList(PERSON_A)));
 
     MeetingRequest request = new MeetingRequest(Arrays.asList(PERSON_A), DURATION_60_MINUTES);
+
+    Collection<TimeRange> actual = query.query(events, request);
+    Collection<TimeRange> expected = Arrays.asList();
+
+    Assert.assertEquals(expected, actual);
+  }
+
+  @Test
+  public void optionalAttendeeWithConflict() {
+    // Have each person have different events. We should see two options because each person has
+    // split the restricted times and we do not require the optional attendee.
+    //
+    // Events  :       |--A--|     |--B--|
+    // Optional: |--------------C--------------|
+    // Day     : |-----------------------------|
+    // Options : |--1--|     |--2--|     |--3--|
+
+    Collection<Event> events =
+        Arrays.asList(
+            new Event(
+                "Event 1",
+                TimeRange.fromStartDuration(TIME_0800AM, DURATION_30_MINUTES),
+                Arrays.asList(PERSON_A)),
+            new Event(
+                "Event 2",
+                TimeRange.fromStartDuration(TIME_0900AM, DURATION_30_MINUTES),
+                Arrays.asList(PERSON_B)),
+            new Event(
+                "Event 3",
+                TimeRange.WHOLE_DAY,
+                Arrays.asList(PERSON_C)));
+
+    MeetingRequest request =
+        new MeetingRequest(Arrays.asList(PERSON_A, PERSON_B), DURATION_30_MINUTES);
+    request.addOptionalAttendee(PERSON_C);
+
+    Collection<TimeRange> actual = query.query(events, request);
+    Collection<TimeRange> expected =
+        Arrays.asList(
+            TimeRange.fromStartEnd(TimeRange.START_OF_DAY, TIME_0800AM, false),
+            TimeRange.fromStartEnd(TIME_0830AM, TIME_0900AM, false),
+            TimeRange.fromStartEnd(TIME_0930AM, TimeRange.END_OF_DAY, true));
+
+    Assert.assertEquals(expected, actual);
+  }
+
+  @Test
+  public void optionalAttendeeNoConflict() {
+    // Have each person have different events. We should see two options because each person has
+    // split the restricted times and we do not require the optional attendee.
+    //
+    // Events  :       |--A--|     |--B--|
+    // Optional:             |--C--|
+    // Day     : |-------------------------------|
+    // Options : |--1--|                   |--2--|
+
+    Collection<Event> events =
+        Arrays.asList(
+            new Event(
+                "Event 1",
+                TimeRange.fromStartDuration(TIME_0800AM, DURATION_30_MINUTES),
+                Arrays.asList(PERSON_A)),
+            new Event(
+                "Event 2",
+                TimeRange.fromStartDuration(TIME_0900AM, DURATION_30_MINUTES),
+                Arrays.asList(PERSON_B)),
+            new Event(
+                "Event 3",
+                TimeRange.fromStartDuration(TIME_0830AM, DURATION_30_MINUTES),
+                Arrays.asList(PERSON_C)));
+
+    MeetingRequest request =
+        new MeetingRequest(Arrays.asList(PERSON_A, PERSON_B), DURATION_30_MINUTES);
+    request.addOptionalAttendee(PERSON_C);
+
+    Collection<TimeRange> actual = query.query(events, request);
+    Collection<TimeRange> expected =
+        Arrays.asList(
+            TimeRange.fromStartEnd(TimeRange.START_OF_DAY, TIME_0800AM, false),
+            TimeRange.fromStartEnd(TIME_0930AM, TimeRange.END_OF_DAY, true));
+
+    Assert.assertEquals(expected, actual);
+  }
+
+  @Test
+  public void justEnoughRoomWithOptionalAttendee() {
+    // Have one person, but make it so that there is just enough room at one point in the day to
+    // have the meeting, and add another optional person with too small of a timeframe.
+    //
+    // Events  : |--A--|     |----A----|
+    // Optional:       |--B--|
+    // Day     : |---------------------|
+    // Options :       |-----|
+
+    Collection<Event> events =
+        Arrays.asList(
+            new Event(
+                "Event 1",
+                TimeRange.fromStartEnd(TimeRange.START_OF_DAY, TIME_0830AM, false),
+                Arrays.asList(PERSON_A)),
+            new Event(
+                "Event 2",
+                TimeRange.fromStartEnd(TIME_0900AM, TimeRange.END_OF_DAY, true),
+                Arrays.asList(PERSON_A)),
+            new Event(
+                "Event 3",
+                TimeRange.fromStartEnd(TIME_0830AM, TIME_0900AM, true),
+                Arrays.asList(PERSON_B)));
+
+    MeetingRequest request = new MeetingRequest(Arrays.asList(PERSON_A), DURATION_30_MINUTES);
+    request.addOptionalAttendee(PERSON_B);
+
+    Collection<TimeRange> actual = query.query(events, request);
+    Collection<TimeRange> expected =
+        Arrays.asList(TimeRange.fromStartDuration(TIME_0830AM, DURATION_30_MINUTES));
+
+    Assert.assertEquals(expected, actual);
+  }
+
+  @Test
+  public void onlyOptionalAttendeesWithGaps() {
+    // Have no mandatory attendees, just two optional attendees with several gaps in their schedules.
+    // Those gaps should be identified and returned.
+    // Events  :   |A||B| |-A-| 
+    // Day     : |---------------------|
+    // Options : |-|    |-|   |--------|
+
+    Collection<Event> events =
+        Arrays.asList(
+            new Event(
+                "Event 1",
+                TimeRange.fromStartDuration(TIME_0830AM, DURATION_30_MINUTES),
+                Arrays.asList(PERSON_A)),
+            new Event(
+                "Event 2",
+                TimeRange.fromStartDuration(TIME_0930AM, DURATION_30_MINUTES),
+                Arrays.asList(PERSON_B)),
+            new Event(
+                "Event 3",
+                TimeRange.fromStartDuration(TIME_1030AM, DURATION_60_MINUTES),
+                Arrays.asList(PERSON_A)));
+
+
+    MeetingRequest request = new MeetingRequest(Arrays.asList(), DURATION_30_MINUTES);
+    request.addOptionalAttendee(PERSON_A);
+    request.addOptionalAttendee(PERSON_B);
+
+    Collection<TimeRange> actual = query.query(events, request);
+    Collection<TimeRange> expected =
+        Arrays.asList(TimeRange.fromStartDuration(TimeRange.START_OF_DAY, TIME_0830AM),
+            TimeRange.fromStartDuration(TIME_0900AM, TIME_0930AM),
+            TimeRange.fromStartDuration(TIME_1000AM, TIME_1030AM),
+            TimeRange.fromStartEnd(TIME_1130AM, TimeRange.END_OF_DAY, true));
+
+    Assert.assertEquals(expected, actual);
+  }
+
+  @Test
+  public void onlyOptionalAttendeesWithNoGaps() {
+    // Have no mandatory attendees, just two optional attendees with several gaps in their schedules.
+    // Those gaps should be identified and returned.
+    // Events  : |----------A----------|
+    //           |----------B----------|
+    // Day     : |---------------------|
+    // Options : 
+
+    Collection<Event> events =
+        Arrays.asList(
+            new Event(
+                "Event 1",
+                TimeRange.fromStartDuration(TimeRange.START_OF_DAY, TimeRange.END_OF_DAY),
+                Arrays.asList(PERSON_A)),
+            new Event(
+                "Event 1",
+                TimeRange.fromStartDuration(TimeRange.START_OF_DAY, TimeRange.END_OF_DAY),
+                Arrays.asList(PERSON_B)));
+
+    MeetingRequest request = new MeetingRequest(Arrays.asList(), DURATION_30_MINUTES);
+    request.addOptionalAttendee(PERSON_A);
+    request.addOptionalAttendee(PERSON_B);
 
     Collection<TimeRange> actual = query.query(events, request);
     Collection<TimeRange> expected = Arrays.asList();

--- a/walkthroughs/week-5-tdd/project/src/test/java/com/google/sps/FindMeetingQueryTest.java
+++ b/walkthroughs/week-5-tdd/project/src/test/java/com/google/sps/FindMeetingQueryTest.java
@@ -458,9 +458,9 @@ public final class FindMeetingQueryTest {
 
     Collection<TimeRange> actual = query.query(events, request);
     Collection<TimeRange> expected =
-        Arrays.asList(TimeRange.fromStartDuration(TimeRange.START_OF_DAY, TIME_0830AM),
-            TimeRange.fromStartDuration(TIME_0900AM, TIME_0930AM),
-            TimeRange.fromStartDuration(TIME_1000AM, TIME_1030AM),
+        Arrays.asList(TimeRange.fromStartEnd(TimeRange.START_OF_DAY, TIME_0830AM, false),
+            TimeRange.fromStartDuration(TIME_0900AM, DURATION_30_MINUTES),
+            TimeRange.fromStartDuration(TIME_1000AM, DURATION_30_MINUTES),
             TimeRange.fromStartEnd(TIME_1130AM, TimeRange.END_OF_DAY, true));
 
     Assert.assertEquals(expected, actual);
@@ -470,7 +470,7 @@ public final class FindMeetingQueryTest {
   public void onlyOptionalAttendeesWithNoGaps() {
     // Have no mandatory attendees, just two optional attendees with several gaps in their schedules.
     // Those gaps should be identified and returned.
-    // Events  : |----------A----------|
+    // Optional: |----------A----------|
     //           |----------B----------|
     // Day     : |---------------------|
     // Options : 


### PR DESCRIPTION
In order to allow users to pick optional attendees as a feature, unit tests were first added as part of test-driven development. Then, basic functionality of optional attendees was added; if one or more time slots exists so that both mandatory and optional attendees can attend, return those time slots and otherwise, return the time slots that fit just the mandatory attendees.

After adding the 5 tests asked, this now passes 26 unit tests. Additionally, the algorithm is now split into different methods to make readability easier. 

Personal portfolio project cards now have spacing underneath.