### PR TITLE
Fix Travel Geolocations

### DIFF
--- a/portfolio/src/main/webapp/WEB-INF/marker-data.csv
+++ b/portfolio/src/main/webapp/WEB-INF/marker-data.csv
@@ -16,8 +16,8 @@
 44.260937,-103.3684,mount rushmore - sd - usa
 37.317207,-111.0263,zion national park - ut - usa
 36.952766,-113.022537,antelope canyon - az - usa
-36.8792,111.5104,horseshoe bend - az - usa
-44.428,110.5885,yellowstone national park - wy - usa
+36.8792,-111.5104,horseshoe bend - az - usa
+44.428,-110.5885,yellowstone national park - wy - usa
 31.2304,121.4737,shanghai - china
 25.033,121.5654,taipei - taiwan
 21.9483,120.7798,kenting - taiwan


### PR DESCRIPTION
For Horseshoe Bend and Yellowstone National Park, the geolocations were off and I had to include a negative to fix it.

![image](https://user-images.githubusercontent.com/20546538/88253471-ee99aa80-cc66-11ea-80de-549cd76473f8.png)
